### PR TITLE
specify sparse matrix for scPred object

### DIFF
--- a/R/eigenDecompose.R
+++ b/R/eigenDecompose.R
@@ -92,7 +92,7 @@ eigenDecompose <- function(expData, n = 10, pseudo = TRUE, returnData = TRUE, se
   svd <- svd[c("x", "rotation", "center", "scale", "sdev")]
   
   if(returnData){
-    return(new("scPred", svd = svd, expVar = varianceExplained, pseudo = pseudo, trainData = Matrix(t(expData))))
+    return(new("scPred", svd = svd, expVar = varianceExplained, pseudo = pseudo, trainData = Matrix(t(expData), sparse=TRUE)))
     
   }else{
     return(new("scPred", svd = svd, expVar = varianceExplained, pseudo = pseudo)) 


### PR DESCRIPTION
When an ScPred object is instantiated in `eigenDecompose.R`, training matrix is coerced into a class `Matrix`. It is expected that a sparse matrix is produced, however, when more that a half of its entries are non-zero, a dense `dgeMatrix` is created by default. This leads to an error in object generation. The issue is solved by adding `sparse=TRUE` parameter. 